### PR TITLE
Update X2Effect_CloseEncounters.uc

### DIFF
--- a/XCOM2RPGOverhaul/Src/RPGO/Classes/X2Effect_CloseEncounters.uc
+++ b/XCOM2RPGOverhaul/Src/RPGO/Classes/X2Effect_CloseEncounters.uc
@@ -41,6 +41,12 @@ function bool PostAbilityCostPaid(XComGameState_Effect EffectState, XComGameStat
 		return false;
 	}
 
+	if (PreCostActionPoints.Find('LW2WotC_RunAndGun') != -1)
+	{
+		`LOG(self.Class.Name @ GetFuncName() @ "LW2 RunAndGun", bLog, 'RPG');
+		return false;
+	}
+
 	if (kAbility == none)
 	{
 		`LOG(self.Class.Name @ GetFuncName() @ "kAbility", bLog, 'RPG');


### PR DESCRIPTION
Fixed CE working after activating the LW2 Classes & Perks versions of Run And Gun (it's not supposed to).