### PR TITLE
Random Classes improvements

### DIFF
--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/RPGO_Structs.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/RPGO_Structs.uc
@@ -44,9 +44,12 @@ struct SpecializationMetaInfoStruct
 	var bool bUseForRandomClasses;
 	var array<name> AllowedWeaponCategories;
 	var array<EInventorySlot> InventorySlots;
-	var array<name> SpecializationRoles;
+	var array<name> SpecializationRoles;	//	Seems to be unused, delete?-Iri
+	var array<name> MutuallyExclusiveSpecs;
 
 	//	This specialization can be rolled only as Primary one, and then will provide access to the same AllowedWeaponCategories for both weapon slots.
+	//	It can also be rolled as Secondary to a non-Dual Wield primary spec that uses same weapons in the same slots.
+	//	It can also be rolled as Complementary to a primary Dual Wield spec, even if bCantBeComplementary = true.
 	var bool bDualWield;
 
 	//	Use to determine whether this specialization is valid to complement other soldier's specializations.

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
@@ -153,6 +153,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 	local array<X2UniversalSoldierClassInfo>	SelectedSpecTemplates;
 	local X2UniversalSoldierClassInfo			SpecTemplate;
 	local array<int>							ReturnArray;
+	local bool									bSkipSpec;
 	local int i;
 
 	`LOG(default.class @ GetFuncName() @ "Start profiling with Random Class SWO",, 'RPG');
@@ -160,6 +161,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 	`LOG("=====================================================",, 'RPG');
 	`LOG("Building random class for: " @ UnitState.GetFullName(),, 'RPG');
 
+	//	Minimum number of specs we should assign to the soldier, configured with MCM.
 	Count = GetSpecRouletteCount();
 	AllSpecTemplates = class'X2SoldierClassTemplatePlugin'.static.GetSpecializationTemplatesAvailableToSoldier(UnitState);
 
@@ -185,7 +187,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 
 	//	Record specialization index as a unit value so it can be looked at in class'X2TemplateHelper_RPGOverhaul'.static.CanAddItemToInventory
 	UnitState.SetUnitFloatValue('PrimarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name), eCleanup_Never);
-	`LOG("SELECTD Primary specialization: " @ SpecTemplate.Name,, 'RPG');
+	`LOG("SELECTED Primary specialization: " @ SpecTemplate.Name,, 'RPG');
 
 	//	Add complementary specializations, if necessary
 	AddComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
@@ -209,6 +211,17 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 			//	Skip specialization if it was already selected
 			if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
 
+			//	Skip specialization if it's mutually exclusive with one of the selected ones.
+			for (i = 0; i < SelectedSpecTemplates.Length; i++)
+			{
+				if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 
+				{
+					bSkipSpec = true;
+					break;
+				}
+			}
+			if (bSkipSpec) continue;
+
 			if (SpecTemplate.IsSecondaryWeaponSpecialization())
 			{
 				for (i = 0; i < SpecTemplate.SpecializationMetaInfo.iWeightSecondary; i++)
@@ -225,7 +238,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 		Count--;
 
 		UnitState.SetUnitFloatValue('SecondarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name), eCleanup_Never);
-		`LOG("SELECTD Secondary specialization: " @ SpecTemplate.Name,, 'RPG');
+		`LOG("SELECTED Secondary specialization: " @ SpecTemplate.Name,, 'RPG');
 
 		//	Add complementary specializations, if necessary
 		AddComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
@@ -245,6 +258,17 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 			//	Skip specialization if it was already selected
 			if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
 
+			//	Skip specialization if it's mutually exclusive with one of the selected ones.
+			for (i = 0; i < SelectedSpecTemplates.Length; i++)
+			{
+				if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 
+				{
+					bSkipSpec = true;
+					break;
+				}
+			}
+			if (bSkipSpec) continue;
+
 			if (class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeComplementary(SelectedSpecTemplates, SpecTemplate))
 			{
 				for (i = 0; i < SpecTemplate.SpecializationMetaInfo.iWeightComplementary; i++)
@@ -263,7 +287,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 		ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name));
 		Count--;
 
-		`LOG("SELECTD Additional specialization: " @ SpecTemplate.Name,, 'RPG');
+		`LOG("SELECTED Additional specialization: " @ SpecTemplate.Name,, 'RPG');
 	}
 	return ReturnArray;
 }

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
@@ -259,6 +259,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 			if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
 
 			//	Skip specialization if it's mutually exclusive with one of the selected ones.
+			bSkipSpec = false;
 			for (i = 0; i < SelectedSpecTemplates.Length; i++)
 			{
 				if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
@@ -212,6 +212,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 			if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
 
 			//	Skip specialization if it's mutually exclusive with one of the selected ones.
+			bSkipSpec = false;
 			for (i = 0; i < SelectedSpecTemplates.Length; i++)
 			{
 				if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SoldierClassTemplatePlugin.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SoldierClassTemplatePlugin.uc
@@ -91,28 +91,38 @@ static function bool IsSpecializationValidToBeComplementary(array<X2UniversalSol
 	local X2UniversalSoldierClassInfo CycleSpecTemplate;
 
 	//	Specialization cannot be used if it's missing meta information
-	//	Or it is explicitly forbidden from being complementary
-	if (!SpecTemplate.SpecializationMetaInfo.bUseForRandomClasses ||
-		SpecTemplate.SpecializationMetaInfo.bCantBeComplementary)
+	
+	if (SpecTemplate.SpecializationMetaInfo.bUseForRandomClasses)
 	{
-		return false;
-	}
-
-	//	If the Spec Template is Universal, then it can Complement any other specialization just fine.
-	if (SpecTemplate.IsComplemtarySpecialization()) return true;
-
-	//	Otherwise, cycle through Specs that have already been selected.
-	foreach SelectedSpecTemplates(CycleSpecTemplate)
-	{
-		//	At least one of the selected specializations roughly does the same thing as this specialization, then this specialization can complement that one.
-		if (DoSpecializationsUseTheSameSlots(CycleSpecTemplate, SpecTemplate) &&
-			DoSpecializationsUseTheSameWeapons(CycleSpecTemplate, SpecTemplate) ||
-			 SpecTemplate.SpecializationMetaInfo.bShoot && CycleSpecTemplate.SpecializationMetaInfo.bShoot ||
-			 SpecTemplate.SpecializationMetaInfo.bGremlin && CycleSpecTemplate.SpecializationMetaInfo.bGremlin ||
-			 SpecTemplate.SpecializationMetaInfo.bPsionic && CycleSpecTemplate.SpecializationMetaInfo.bPsionic ||
-			 SpecTemplate.SpecializationMetaInfo.bMelee && CycleSpecTemplate.SpecializationMetaInfo.bMelee)
+		//	If this spec is marked as Dual Wield one, it can be selected as a complementary spec to a primary spec that is also dual wield and uses the same weapons in the same slots.
+		if (SpecTemplate.SpecializationMetaInfo.bDualWield && SelectedSpecTemplates.Length > 0 && SelectedSpecTemplates[0].SpecializationMetaInfo.bDualWield &&
+			DoSpecializationsUseTheSameSlots(SelectedSpecTemplates[0], SpecTemplate) && DoSpecializationsUseTheSameWeapons(SelectedSpecTemplates[0], SpecTemplate))
 		{
-			return true;
+			 return true;
+		}
+
+		//	Exit now if the spec is explicitly forbidden from being complementary.
+		if (SpecTemplate.SpecializationMetaInfo.bCantBeComplementary)
+		{
+			return false;
+		}
+		
+		//	If the Spec Template is Universal, then it can Complement any other specialization just fine.
+		if (SpecTemplate.IsComplemtarySpecialization()) return true;
+
+		//	Otherwise, cycle through Specs that have already been selected.
+		foreach SelectedSpecTemplates(CycleSpecTemplate)
+		{
+			//	At least one of the selected specializations roughly does the same thing as this specialization, then this specialization can complement that one.
+			if (DoSpecializationsUseTheSameSlots(CycleSpecTemplate, SpecTemplate) &&
+				DoSpecializationsUseTheSameWeapons(CycleSpecTemplate, SpecTemplate) ||
+				 SpecTemplate.SpecializationMetaInfo.bShoot && CycleSpecTemplate.SpecializationMetaInfo.bShoot ||
+				 SpecTemplate.SpecializationMetaInfo.bGremlin && CycleSpecTemplate.SpecializationMetaInfo.bGremlin ||
+				 SpecTemplate.SpecializationMetaInfo.bPsionic && CycleSpecTemplate.SpecializationMetaInfo.bPsionic ||
+				 SpecTemplate.SpecializationMetaInfo.bMelee && CycleSpecTemplate.SpecializationMetaInfo.bMelee)
+			{
+				return true;
+			}
 		}
 	}
 	return false;

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2UniversalSoldierClassInfo.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2UniversalSoldierClassInfo.uc
@@ -111,7 +111,8 @@ function bool IsPrimaryWeaponSpecialization()
 
 function bool IsSecondaryWeaponSpecialization()
 {
-	return SpecializationMetaInfo.AllowedWeaponCategories.Length > 0 && SpecializationMetaInfo.InventorySlots.Find(eInvSlot_SecondaryWeapon) != INDEX_NONE;
+	//	Spec is valid to be secondary if it allows using specific weapons in the secondary slot OR if it's a valid primary spec that is also a Dual Wield spec
+	return SpecializationMetaInfo.AllowedWeaponCategories.Length > 0 && (SpecializationMetaInfo.InventorySlots.Find(eInvSlot_SecondaryWeapon) != INDEX_NONE || SpecializationMetaInfo.bDualWield && IsPrimaryWeaponSpecialization());
 }
 
 function bool IsComplemtarySpecialization()


### PR DESCRIPTION
Dual Wield specs can become complementary to a primary Dual Wield spec even if they have bCantBeComplementary = true. Dual Wield specs can become Secondary specs if the non-Dual Wield primary spec uses the same inventory slots/weapons.