### PR TITLE
Random Classes Improvements and Fixes

### DIFF
--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/RPGO_Structs.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/RPGO_Structs.uc
@@ -47,6 +47,12 @@ struct SpecializationMetaInfoStruct
 	// This are the weapon categories provided when the Weapon Restriction SWO is enabled
 	var array<name> AllowedWeaponCategories;
 
+	// If weapon restrictions are enabled, Random Classes will allow this spec to be picked as secondary or complementary
+	// only if the soldier can use one of the weapon categories specified in this array. 
+	// Useful for a potential Ballistic Shield spec, or Mitzruti's Chemtrhower Canister specs.
+	// This array is not used when the spec is considered to be primary.
+	var array<name> RequiredWeaponCategories;
+
 	// The weapon categories are supplied to these inventory slots. This is also used by the Random Classes SWO algorithm
 	var array<EInventorySlot> InventorySlots;
 
@@ -78,6 +84,7 @@ struct SpecializationMetaInfoStruct
 	var bool bPsionic;
 
 	//	this spec can be used only as primary or secondary, but cannot complement other specs. "Skirmisher" spec is a good example, as it pretty much requires a ripjack to function. 
+	//	Exception: Dual Wield specs can become complementary even if bCantBeComplementary = true
 	var bool bCantBeComplementary;
 
 	// Weights used by the Random Classes SWO algorithm

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2EventListener_RPG_StrategyListener.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2EventListener_RPG_StrategyListener.uc
@@ -857,7 +857,8 @@ public static function WeaponRestrictions_EquipNewWeaponsOnSoldier(int UnitObjec
 			}
 		}
 	}
- 
+	//	Hard reset local var before using it again - just in case.
+	OldWeaponState = none;
 	OldWeaponState = UnitState.GetItemInSlot(eInvSlot_SecondaryWeapon);
 	if (OldWeaponState != none)
 	{
@@ -874,10 +875,10 @@ public static function WeaponRestrictions_EquipNewWeaponsOnSoldier(int UnitObjec
 			if (UnitState.RemoveItemFromInventory(OldWeaponState, NewGameState))
 			{
 				NewWeaponState = FindBestInfiniteWeaponForUnit(UnitState, eInvSlot_SecondaryWeapon, AllowedWeaponCategories, XComHQ, NewGameState);
-				NewWeaponState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', NewWeaponState.ObjectID));
-
+				
 				if (NewWeaponState != none)
 				{
+					NewWeaponState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', NewWeaponState.ObjectID));
 					if (UnitState.AddItemToInventory(NewWeaponState, eInvSlot_SecondaryWeapon, NewGameState))
 					{
 						//`LOG("New Secondary Weapon " @ NewWeaponState.GetMyTemplateName(),, 'RPG');
@@ -897,10 +898,10 @@ public static function WeaponRestrictions_EquipNewWeaponsOnSoldier(int UnitObjec
 	{
 		AllowedWeaponCategories = class'X2SoldierClassTemplatePlugin'.static.GetAllowedSecondaryWeaponCategories(UnitState);
 		NewWeaponState = FindBestInfiniteWeaponForUnit(UnitState, eInvSlot_SecondaryWeapon, AllowedWeaponCategories, XComHQ, NewGameState);
-		NewWeaponState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', NewWeaponState.ObjectID));
-
+		
 		if (NewWeaponState != none)
 		{
+			NewWeaponState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', NewWeaponState.ObjectID));
 			if (UnitState.AddItemToInventory(NewWeaponState, eInvSlot_SecondaryWeapon, NewGameState))
 			{
 				//`LOG("New Secondary Weapon " @ NewWeaponState.GetMyTemplateName(),, 'RPG');

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SecondWaveConfigOptions.uc
@@ -180,13 +180,125 @@ static function array<int> GetRandomSpecIndices(XComGameState_Unit UnitState, in
 }
 
 //	Random Classes
+
+static function MaybeAddSpecAsRequired(const XComGameState_Unit UnitState, const X2UniversalSoldierClassInfo SpecTemplate, out array<X2UniversalSoldierClassInfo> RequiredSpecTemplates)
+{
+	local name AbilityName;
+	local X2UniversalSoldierClassInfo RequiredSpecTemplate;
+
+	//	If this spec doesn't have any Required Abilities specified, exit early.
+	if (SpecTemplate.RequiredAbilities.Length == 0)
+		return;
+
+	//	If this spec is already in the array of required specs, exit early.
+	if (RequiredSpecTemplates.Find(SpecTemplate) != INDEX_NONE)
+		return;
+
+	//	Cycle through all required abilities for this spec
+	foreach SpecTemplate.RequiredAbilities(AbilityName)
+	{
+		//	If the soldier doesn't have one of them, exit function.
+		if (!UnitState.HasSoldierAbility(AbilityName, false))
+		{
+			return;
+		}
+	}
+
+	//	If any of required specs list this spec as mutually exclusive, then exit function.
+	if (IsSpecMutuallyExclusive(SpecTemplate, RequiredSpecTemplates))
+	{	
+		return;
+	}
+	
+	//	All checks passed, add the spec into the array of required specs.
+	RequiredSpecTemplates.AddItem(SpecTemplate);
+}
+
+static function AddSpecAsValid(const X2UniversalSoldierClassInfo SpecTemplate, const int iWeight, out array<X2UniversalSoldierClassInfo> ValidSpecTemplates)
+{
+	local int i;
+
+	`LOG("Valid spec: " @ SpecTemplate.Name @ "Weight:" @ iWeight,, 'RPG');
+
+	for (i = 0; i < iWeight; i++)
+	{
+		ValidSpecTemplates.AddItem(SpecTemplate);
+	}
+}
+
+static function bool IsSpecMutuallyExclusive(const X2UniversalSoldierClassInfo SpecTemplate, const array<X2UniversalSoldierClassInfo> SelectedSpecTemplates)
+{
+	local X2UniversalSoldierClassInfo SelectedSpecTemplate;
+
+	//	Cycle through all specs that have been selected so far
+	foreach SelectedSpecTemplates(SelectedSpecTemplate)
+	{
+		//	If at least one of them marks this spec as mutually exclusive
+		if (SelectedSpecTemplate.SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 
+		{
+			//	Return true, signaling that the spec is mutually exclusive.
+			return true;
+		}
+	}
+	return false;
+}
+
+static function array<X2UniversalSoldierClassInfo> BuildValidSecondarySpecs(const array<X2UniversalSoldierClassInfo> AllSpecTemplates, const array<X2UniversalSoldierClassInfo> SelectedSpecTemplates)
+{
+	local X2UniversalSoldierClassInfo			SpecTemplate;
+	local array<X2UniversalSoldierClassInfo>	ValidSpecTemplates;
+
+	foreach AllSpecTemplates(SpecTemplate)
+	{	
+		//	Skip specialization if it was already selected
+		if (SelectedSpecTemplates.Find(SpecTemplate) != INDEX_NONE) continue;
+		
+		//	Skip specialization if it's mutually exclusive with one of the selected ones.
+		if (IsSpecMutuallyExclusive(SpecTemplate, SelectedSpecTemplates)) continue;
+
+		if (class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeSecondary(SelectedSpecTemplates, SpecTemplate))
+		{
+			AddSpecAsValid(SpecTemplate, SpecTemplate.SpecializationMetaInfo.iWeightSecondary, ValidSpecTemplates);
+		}
+	}
+	return ValidSpecTemplates;
+}
+
+static function array<X2UniversalSoldierClassInfo> BuildValidComplementarySpecs(const array<X2UniversalSoldierClassInfo> AllSpecTemplates, const array<X2UniversalSoldierClassInfo> SelectedSpecTemplates)
+{
+	local X2UniversalSoldierClassInfo			SpecTemplate;
+	local array<X2UniversalSoldierClassInfo>	ValidSpecTemplates;
+
+	foreach AllSpecTemplates(SpecTemplate)
+	{	
+		//	Skip specialization if it was already selected
+		if (SelectedSpecTemplates.Find(SpecTemplate) != INDEX_NONE) continue;
+		
+		//	Skip specialization if it's mutually exclusive with one of the selected ones.
+		if (IsSpecMutuallyExclusive(SpecTemplate, SelectedSpecTemplates)) continue;
+
+		if (class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeComplementary(SelectedSpecTemplates, SpecTemplate))
+		{
+			AddSpecAsValid(SpecTemplate, SpecTemplate.SpecializationMetaInfo.iWeightSecondary, ValidSpecTemplates);
+		}
+	}
+	return ValidSpecTemplates;
+}
+
 //	Select specializations for the soldier to randomly create a soldier class.
 static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit UnitState, int Count)
 {
 	local array<X2UniversalSoldierClassInfo>	AllSpecTemplates;
 	local array<X2UniversalSoldierClassInfo>	ValidSpecTemplates;
-	local array<X2UniversalSoldierClassInfo>	SelectedSpecTemplates;
+	local array<X2UniversalSoldierClassInfo>	RequiredSpecTemplates;
 	local X2UniversalSoldierClassInfo			SpecTemplate;
+
+	local X2UniversalSoldierClassInfo			SelectedPrimarySpec, SelectedSecondarySpec;
+	local array<name>							RequiredSpecSelectionArray;
+	local bool									PrimarySpecIsRequired, SecondarySpecIsRequired;
+
+	//	These two arrays should both contain references to same specs.
+	local array<X2UniversalSoldierClassInfo>	SelectedSpecTemplates;
 	local array<int>							ReturnArray;
 	local bool									bSkipSpec;
 	local int i;
@@ -200,123 +312,138 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 
 	//	########################################################
 	//	Select random specialization for primary weapon:
-	`LOG("## Selecting primary specialization:" @ Count,, 'RPG');
+	`LOG("## Selecting primary specialization." @ Count @ "specs left.",, 'RPG');
 	foreach AllSpecTemplates(SpecTemplate)
 	{
+		//	Fill the array with all specs that are *required* for this soldier
+		//	A spec counts as required if the soldier has all abilities listed in the spec's RequiredAbilities array.
+		//	We fill this array only once when cycling through all specs for the first time.
+		MaybeAddSpecAsRequired(UnitState, SpecTemplate, RequiredSpecTemplates);
+		
 		if (SpecTemplate.IsPrimaryWeaponSpecialization())
 		{
-			for (i = 0; i < SpecTemplate.SpecializationMetaInfo.iWeightPrimary; i++)
-			{
-				`LOG("Valid spec: " @ SpecTemplate.Name,, 'RPG');
-				ValidSpecTemplates.AddItem(SpecTemplate);
-			}
+			AddSpecAsValid(SpecTemplate, SpecTemplate.SpecializationMetaInfo.iWeightPrimary, ValidSpecTemplates);
 		}
 	}
 	if (ValidSpecTemplates.Length > 0)
 	{
 		SpecTemplate = ValidSpecTemplates[`SYNC_RAND_STATIC(ValidSpecTemplates.Length)];
 
+		SelectedPrimarySpec = SpecTemplate;
 		SelectedSpecTemplates.AddItem(SpecTemplate);
-		ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name));
+		if (RequiredSpecTemplates.Find(SelectedPrimarySpec) != INDEX_NONE)
+		{	
+			PrimarySpecIsRequired = true;
+			RequiredSpecTemplates.RemoveItem(SpecTemplate);
+		}
 		Count--;
 
-		//	Record specialization index as a unit value so it can be looked at in class'X2TemplateHelper_RPGOverhaul'.static.CanAddItemToInventory
-		UnitState.SetUnitFloatValue('PrimarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name), eCleanup_Never);
-		`LOG("SELECTED Primary specialization: " @ SpecTemplate.Name,, 'RPG');
-
 		//	Add complementary specializations, if necessary
-		AddComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
-
-		//	Exit function early if necessary
-		if (Count <= 0) return ReturnArray;
+		AddForcedComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
 	}
 	else `LOG("There were no valid primary specs to choose from.",, 'RPG');
 
+	//	Exit function early if necessary
+	if (Count <= 0) 
+	{
+		//	Record specialization index as a unit value so it can be looked at in class'X2TemplateHelper_RPGOverhaul'.static.CanAddItemToInventory
+		ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedPrimarySpec.Name));
+		UnitState.SetUnitFloatValue('PrimarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedPrimarySpec.Name), eCleanup_Never);
+		`LOG("SELECTED Primary specialization: " @ SpecTemplate.Name $ ". No more specs left, exiting.",, 'RPG');
+		return ReturnArray;
+	}
+
 	//	########################################################
 	//	Select random specialization for secondary weapon
-	`LOG("## Selecting secondary specialization: " @ Count,, 'RPG');
-	ValidSpecTemplates.Length = 0;
-	foreach AllSpecTemplates(SpecTemplate)
-	{	
-		//	Skip specialization if it was already selected
-		if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
+	`LOG("## Selecting secondary specialization." @ Count @ "specs left.",, 'RPG');
 
-		//	Skip specialization if it's mutually exclusive with one of the selected ones.
-		bSkipSpec = false;
-		for (i = 0; i < SelectedSpecTemplates.Length; i++)
-		{
-			if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 
-			{
-				bSkipSpec = true;
-				break;
-			}
-		}
-		if (bSkipSpec) continue;
+	ValidSpecTemplates = BuildValidSecondarySpecs(AllSpecTemplates, SelectedSpecTemplates);
 
-		if (class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeSecondary(SelectedSpecTemplates, SpecTemplate))
-		{
-			for (i = 0; i < SpecTemplate.SpecializationMetaInfo.iWeightSecondary; i++)
-			{
-				`LOG("Valid spec: " @ SpecTemplate.Name,, 'RPG');
-				ValidSpecTemplates.AddItem(SpecTemplate);
-			}
-		}
-	}
 	if (ValidSpecTemplates.Length > 0)
 	{
 		SpecTemplate = ValidSpecTemplates[`SYNC_RAND_STATIC(ValidSpecTemplates.Length)];
 
+		SelectedSecondarySpec = SpecTemplate;
 		SelectedSpecTemplates.AddItem(SpecTemplate);
-		ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name));
+		if (RequiredSpecTemplates.Find(SelectedSecondarySpec) != INDEX_NONE)
+		{	
+			SecondarySpecIsRequired = true;
+			RequiredSpecTemplates.RemoveItem(SpecTemplate);
+		}
 		Count--;
 
-		UnitState.SetUnitFloatValue('SecondarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name), eCleanup_Never);
-		`LOG("SELECTED Secondary specialization: " @ SpecTemplate.Name,, 'RPG');
-
 		//	Add complementary specializations, if necessary
-		AddComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
-
-		//	Exit function early if necessary
-		if (Count <= 0) return ReturnArray;
+		AddForcedComplementarySpecializations(UnitState, SpecTemplate, ReturnArray, SelectedSpecTemplates, Count);
 	}
 	else `LOG("There were no valid secondary specs to choose from.",, 'RPG');
 
 	//	########################################################
+	//	Assign Required Specs to the soldier during this step.
+	foreach RequiredSpecTemplates(SpecTemplate)
+	{
+		RequiredSpecSelectionArray.Length = 0;
+
+		if (!PrimarySpecIsRequired && SpecTemplate.IsPrimaryWeaponSpecialization()) RequiredSpecSelectionArray.AddItem('ValidPrimarySpec');
+		if (!SecondarySpecIsRequired && class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeSecondary(SelectedSpecTemplates, SpecTemplate)) RequiredSpecSelectionArray.AddItem('ValidSecondarySpec');
+		if (Count > 0 && class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeComplementary(SelectedSpecTemplates, SpecTemplate)) RequiredSpecSelectionArray.AddItem('ValidComplementarySpec');
+
+		//	If this required spec cannot be currently added to the soldier in any capacity, skip it.
+		if (RequiredSpecSelectionArray.Length == 0) continue;
+
+		//	Randomly assign this required spec to be primary, secondary or complementary, as long as those are actually valid positions for it.
+		i = `SYNC_RAND_STATIC(RequiredSpecSelectionArray.Length);
+
+		switch (RequiredSpecSelectionArray[i])
+		{
+			case 'ValidPrimarySpec':
+				SelectedSpecTemplates.RemoveItem(SelectedPrimarySpec);
+				SelectedPrimarySpec = SpecTemplate;
+				SelectedSpecTemplates.AddItem(SpecTemplate);
+				PrimarySpecIsRequired = true;
+				break;
+			case 'ValidSecondarySpec':
+				SelectedSpecTemplates.RemoveItem(SelectedSecondarySpec);
+				SelectedSecondarySpec = SpecTemplate;
+				SelectedSpecTemplates.AddItem(SpecTemplate);
+				SecondarySpecIsRequired = true;
+				break;
+			case 'ValidComplementarySpec':
+				SelectedSpecTemplates.AddItem(SpecTemplate);
+				ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name));
+				Count--;
+				break;
+			default:
+				break;				
+		}		
+	}
+
+	//	########################################################
+	//	Assign Primary and Secondary specs that were selected up to this point.
+	ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedPrimarySpec.Name));
+	UnitState.SetUnitFloatValue('PrimarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedPrimarySpec.Name), eCleanup_Never);
+	`LOG("SELECTED Primary specialization: " @ SpecTemplate.Name $ ". No more specs left, exiting.",, 'RPG');
+
+	ReturnArray.AddItem(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedSecondarySpec.Name));
+	UnitState.SetUnitFloatValue('SecondarySpecialization_Value', class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SelectedSecondarySpec.Name), eCleanup_Never);
+	`LOG("SELECTED Secondary specialization: " @ SelectedSecondarySpec.Name,, 'RPG');
+
+	//	Exit function early if necessary
+	if (Count <= 0) return ReturnArray;
+
+
+	//	########################################################
 	//	Select several additional specializations that either complement already selected specializations, or are weapon agnostic.
-	`LOG("## Selecting additional specializations: " @ Count,, 'RPG');
+	`LOG("## Selecting additional specializations." @ Count @ "specs left.",, 'RPG');
 	while (Count > 0)
 	{
-		ValidSpecTemplates.Length = 0;
-
-		foreach AllSpecTemplates(SpecTemplate)
-		{
-			//	Skip specialization if it was already selected
-			if (ReturnArray.Find(class'X2SoldierClassTemplatePlugin'.static.GetSpecializationIndex(UnitState, SpecTemplate.Name)) != INDEX_NONE) continue;
-
-			//	Skip specialization if it's mutually exclusive with one of the selected ones.
-			bSkipSpec = false;
-			for (i = 0; i < SelectedSpecTemplates.Length; i++)
-			{
-				if (SelectedSpecTemplates[i].SpecializationMetaInfo.MutuallyExclusiveSpecs.Find(SpecTemplate.Name) != INDEX_NONE) 
-				{
-					bSkipSpec = true;
-					break;
-				}
-			}
-			if (bSkipSpec) continue;
-
-			if (class'X2SoldierClassTemplatePlugin'.static.IsSpecializationValidToBeComplementary(SelectedSpecTemplates, SpecTemplate))
-			{
-				for (i = 0; i < SpecTemplate.SpecializationMetaInfo.iWeightComplementary; i++)
-				{
-					`LOG("Valid spec: " @ SpecTemplate.Name,, 'RPG');
-					ValidSpecTemplates.AddItem(SpecTemplate);
-				}
-			}
-		}
+		ValidSpecTemplates = BuildValidComplementarySpecs(AllSpecTemplates, SelectedSpecTemplates);	
 
 		//	Exit function early if there are no valid specs anymore.
-		if (ValidSpecTemplates.Length == 0) return ReturnArray;
+		if (ValidSpecTemplates.Length == 0) 
+		{
+			`LOG("There were no more valid complementary specs to choose from, exiting.",, 'RPG');
+			return ReturnArray;
+		}
 
 		SpecTemplate = ValidSpecTemplates[`SYNC_RAND_STATIC(ValidSpecTemplates.Length)];
 		SelectedSpecTemplates.AddItem(SpecTemplate);
@@ -330,7 +457,7 @@ static function array<int> GetSpecIndices_ForRandomClass(XComGameState_Unit Unit
 
 //	Random Classes
 //	Moved this code into a separate function, since it's getting called multiple times.
-static function AddComplementarySpecializations(
+static function AddForcedComplementarySpecializations(
 	XComGameState_Unit UnitState,
 	X2UniversalSoldierClassInfo SpecTemplate,
 	out array<int> ReturnArray,

--- a/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SoldierClassTemplatePlugin.uc
+++ b/XCOM2RPGOverhaul/Src/XCOM2RPGOverhaul/Classes/X2SoldierClassTemplatePlugin.uc
@@ -372,6 +372,22 @@ static function array<name> GetAllowedSecondaryWeaponCategories(XComGameState_Un
 	return ReturnArray;
 }
 
+static function array<name> GetAllowedPrimaryAndSecondaryWeaponCategories(XComGameState_Unit UnitState)
+{	
+	local array<name>	PrimaryCategories, SecondaryCategories;
+	local name			WeaponCat;
+
+	PrimaryCategories = GetAllowedPrimaryWeaponCategories(UnitState);
+	SecondaryCategories = GetAllowedSecondaryWeaponCategories(UnitState);
+
+	foreach SecondaryCategories(WeaponCat)
+	{
+		PrimaryCategories.AddItem(WeaponCat);
+	}	
+
+	return PrimaryCategories;
+}
+
 static function bool IsPrimaryWeaponCategoryAllowed(XComGameState_Unit UnitState, name WeaponCat)
 {	
 	local array<SoldierSpecialization>	PrimarySpecs;


### PR DESCRIPTION
Bugfix:
-- Complementary specs will now properly add specs that are forced complementary for them.

Feature:
-- If the soldier is valid for a spec that lists RequiredAbilities, then this "Required Specs" will be assigned to the soldier as a priority.

**How it works**
When building an array of valid specs to randomly choose a spec from, Random Classes will add specs that list Required Abilities into a separate array. 

If a spec lists Required Abilities, but the soldier does not have them, then that spec is removed from consideration even before Random Classes have a chance to look at it. 

So if the array of Required Specs has at least one member, the Random Classes will select specs from that array instead.

So if there is ever a situation when more than one spec is Required for a soldier, Random Classes will select one at random.

Priority of spec assignment goes as Primary -> Secondary -> Complementary.

So if a Required Spec can be assigned as Primary, it always will be, unless the primary spec slot is already occupied by a required spec.